### PR TITLE
Use nokogiri < 1.6.8 for Ruby < 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :test do
   gem 'puppet-lint-resource_reference_syntax'
 
   gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+  gem 'nokogiri', '< 1.6.8'   if RUBY_VERSION < '2.1.0'
 end
 
 group :development do

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2016 William Tsoi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Without this patch applied, Nokogiri fails to install with a dependency
problem on Ruby 2.0.0.